### PR TITLE
run experimental releases after full releases

### DIFF
--- a/.changeset/good-nails-leave.md
+++ b/.changeset/good-nails-leave.md
@@ -1,0 +1,6 @@
+---
+"@opendesign/react": patch
+"@opendesign/universal": patch
+---
+
+fix release process

--- a/.github/workflows/experimental-release.yml
+++ b/.github/workflows/experimental-release.yml
@@ -2,9 +2,11 @@ name: Experimental Release
 
 on:
   workflow_dispatch: {}
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows:
+      - "Release"
+    types:
+      - completed
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
*Checklist*

- [x] PR contains changeset (if applicable)

## Why it's needed

Previously we were running experimental releases on push to main, which is good, but they were running  potentially before latest releases. Since changesets use npm to determine what to publish, it was publishing release version in experimental channel which resulted in real release to fail. This fixes that.