### PR TITLE
fix path handling in open subcommand

### DIFF
--- a/.changeset/curly-peas-share.md
+++ b/.changeset/curly-peas-share.md
@@ -1,0 +1,5 @@
+---
+"opendesign": patch
+---
+
+fix opendesign open with relative paths

--- a/packages/opendesign/cli/open.ts
+++ b/packages/opendesign/cli/open.ts
@@ -5,9 +5,9 @@ import { wasm } from "@opendesign/engine-wasm";
 import express from "express";
 import openUrl from "open";
 
-import { expectedError, reflow } from "./utils.js";
+import { expectedError, packageRoot, reflow } from "./utils.js";
 
-const editorDist = new URL("../../dist/editor/", import.meta.url);
+const editorDist = new URL("dist/editor/", packageRoot());
 
 export function execute(args: string[]) {
   const { positionals } = parseArgs({ args, allowPositionals: true });
@@ -38,7 +38,7 @@ export function execute(args: string[]) {
     const filename = path.basename(file);
     url.searchParams.set("file", filename);
     app.get("/designs/" + filename, (req, res) => {
-      res.sendFile(file);
+      res.sendFile(path.join(process.cwd(), file));
     });
   }
   app.listen(url.port, () => {

--- a/packages/opendesign/cli/utils.ts
+++ b/packages/opendesign/cli/utils.ts
@@ -62,3 +62,9 @@ export function expectedError(message: string, cause?: Error) {
 export function isExpectedError(error: any): error is Error {
   return typeof error === "object" && error && expected in error;
 }
+
+export function packageRoot() {
+  if (import.meta.url.endsWith(".ts"))
+    return new URL("..", import.meta.url).href;
+  return new URL("../..", import.meta.url).href;
+}


### PR DESCRIPTION
*Checklist*

- [x] PR contains changeset (if applicable)

- fixes `yarn workspace opendesign dev:cli open` (that's the `packageRoot` function)
- fixes `npx opendesign open ../relative/path/design.xd` (that's the `path.join()`)